### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -30,7 +30,7 @@ class syntax_plugin_magnifier extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{magnifier>[^}]+}}', $mode, 'plugin_magnifier');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 
 	    // {{magnifier>:image:test.png?widthxheight}}
 
@@ -51,7 +51,7 @@ class syntax_plugin_magnifier extends DokuWiki_Syntax_Plugin {
         return array(trim($id), $w, $h, $orig);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $ID, $conf, $JSINFO;
 
         list($id, $w, $h, $orig) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
